### PR TITLE
[npm] Kuzzle as peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   "devDependencies": {
     "@types/node": "^16.6.1",
     "ts-node": "^10.2.0",
-    "typescript": "^4.3.5",
+    "typescript": "^4.3.5"
+  },
+  "peerDependencies": {
     "kuzzle": "^2.14.0"
   }
 }


### PR DESCRIPTION
Kuzzle is now a peer dependency, so that plugins using this package will not have Kuzzle installed.

## Why this?
Because if a Kuzzle Plugin has the Kuzzle package  installed in its `node_modules`, this might cause a version conflict between the versions of Kuzzle in the plugin, and the one in the host app. Typically, Typescript will throw errors due to type mismatch caused by non-breaking changes in subsequent versions of Kuzzle.