### PR TITLE
fix(deps): explictly define lodash as a dependency

### DIFF
--- a/.github/workflows/pull_request.workflow.yml
+++ b/.github/workflows/pull_request.workflow.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
 
@@ -28,7 +28,7 @@ jobs:
 
   check-types:
     name: Check types
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v6

--- a/.github/workflows/pull_request.workflow.yml
+++ b/.github/workflows/pull_request.workflow.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
-          node-version: 16
+          node-version: 18
       - name: Install dependencies
         run: npm ci
       - name: Run types tests

--- a/.github/workflows/push_branches.workflow.yaml
+++ b/.github/workflows/push_branches.workflow.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   release:
     name: Release process
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
       issues: write

--- a/.github/workflows/push_branches.workflow.yaml
+++ b/.github/workflows/push_branches.workflow.yaml
@@ -24,7 +24,7 @@ jobs:
           ssh-private-key: ${{ secrets.SSH_KEY }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: "lts/*"
           registry-url: "https://registry.npmjs.org"

--- a/lib/config/ConfigManager.ts
+++ b/lib/config/ConfigManager.ts
@@ -95,7 +95,7 @@ export class ConfigManager {
   private get app() {
     if (!this.isApp) {
       throw new PluginImplementationError(
-        "ConfigManager was intantiated from a plugin"
+        "ConfigManager was intantiated from a plugin",
       );
     }
 
@@ -105,7 +105,7 @@ export class ConfigManager {
   private get plugin() {
     if (this.isApp) {
       throw new PluginImplementationError(
-        "ConfigManager was intantiated from an application"
+        "ConfigManager was intantiated from an application",
       );
     }
 
@@ -118,7 +118,7 @@ export class ConfigManager {
 
   constructor(
     appOrPlugin: Backend | Plugin,
-    options: ConfigManagerOptions = {}
+    options: ConfigManagerOptions = {},
   ) {
     this.appOrPlugin = appOrPlugin;
 
@@ -147,7 +147,7 @@ export class ConfigManager {
   register(type: string, mappings: JSONObject) {
     if (this.configurations.has(type)) {
       throw new PluginImplementationError(
-        `Config for "${type}" already registered.`
+        `Config for "${type}" already registered.`,
       );
     }
 
@@ -160,7 +160,7 @@ export class ConfigManager {
   async createCollection(
     index: string,
     mappingsOverride: JSONObject = {},
-    settingsOverride: JSONObject = {}
+    settingsOverride: JSONObject = {},
   ) {
     const fullMappings = _.merge({}, this.baseMappings, mappingsOverride);
     const fullSettings = _.merge({}, this.baseSettings, settingsOverride);
@@ -207,7 +207,7 @@ export class ConfigManager {
         document._id = `${document._source.type}--${name}`;
       } catch (error) {
         throw new PluginImplementationError(
-          `Error when generating ID for config document of type "${document._source.type}": ${error}`
+          `Error when generating ID for config document of type "${document._source.type}": ${error}`,
         );
       }
     }
@@ -219,7 +219,7 @@ export class ConfigManager {
     if (this.isApp) {
       this.app.pipe.register(
         "generic:document:beforeWrite",
-        this.generateID.bind(this)
+        this.generateID.bind(this),
       );
 
       return;
@@ -231,7 +231,7 @@ export class ConfigManager {
 
     if (!_.isArray(this.plugin.pipes["generic:document:beforeWrite"])) {
       throw new PluginImplementationError(
-        'Handler on "generic:document:beforeWrite" must be an array'
+        'Handler on "generic:document:beforeWrite" must be an array',
       );
     }
 

--- a/lib/crud/CRUDController.ts
+++ b/lib/crud/CRUDController.ts
@@ -45,7 +45,7 @@ export class CRUDController {
       this.collection,
       asset,
       id,
-      { ...request.input.args }
+      { ...request.input.args },
     );
   }
 
@@ -62,7 +62,7 @@ export class CRUDController {
       index,
       this.collection,
       id,
-      { ...request.input.args }
+      { ...request.input.args },
     );
   }
 
@@ -102,7 +102,7 @@ export class CRUDController {
       this.collection,
       id,
       body,
-      { ...request.input.args }
+      { ...request.input.args },
     );
   }
 }

--- a/lib/engine/AbstractEngine.ts
+++ b/lib/engine/AbstractEngine.ts
@@ -39,7 +39,7 @@ export abstract class AbstractEngine<TPlugin extends Plugin> {
     plugin: Plugin,
     adminIndex: string,
     adminConfigManager: ConfigManager,
-    engineConfigManager: ConfigManager
+    engineConfigManager: ConfigManager,
   ) {
     this.pluginName = pluginName;
     this.config = plugin.config;
@@ -51,39 +51,39 @@ export abstract class AbstractEngine<TPlugin extends Plugin> {
     this.configType = `engine-${this.pluginName}`;
   }
 
-  async init(...args: unknown[]): Promise<any> {
+  async init(): Promise<any> {
     // Can be used to inject other services into the engine
   }
   protected abstract onCreate(
     index: string,
     group: string,
-    request?: KuzzleRequest
+    request?: KuzzleRequest,
   ): Promise<{ collections: string[] }>;
   protected abstract onUpdate(
     index: string,
     group: string,
-    request?: KuzzleRequest
+    request?: KuzzleRequest,
   ): Promise<{ collections: string[] }>;
   protected abstract onDelete(
     index: string,
-    request?: KuzzleRequest
+    request?: KuzzleRequest,
   ): Promise<{ collections: string[] }>;
 
   async create(
     index: string,
     group = "commons",
-    request?: KuzzleRequest
+    request?: KuzzleRequest,
   ): Promise<{ collections: string[] }> {
     if (await this.exists(index)) {
       throw new BadRequestError(
         `${Inflector.upFirst(
-          this.pluginName
-        )} engine on index "${index}" already exists`
+          this.pluginName,
+        )} engine on index "${index}" already exists`,
       );
     }
 
     this.context.log.info(
-      `Create ${this.pluginName} engine on index "${index}"`
+      `Create ${this.pluginName} engine on index "${index}"`,
     );
 
     await this.createEngineIndex(index);
@@ -99,7 +99,7 @@ export abstract class AbstractEngine<TPlugin extends Plugin> {
         type: this.configType,
       },
       this.engineId(index),
-      { refresh: "wait_for" }
+      { refresh: "wait_for" },
     );
 
     return { collections };
@@ -108,18 +108,18 @@ export abstract class AbstractEngine<TPlugin extends Plugin> {
   async update(
     index: string,
     group = "commons",
-    request?: KuzzleRequest
+    request?: KuzzleRequest,
   ): Promise<{ collections: string[] }> {
     if (!(await this.exists(index))) {
       throw new NotFoundError(
         `${Inflector.upFirst(
-          this.pluginName
-        )} engine on index "${index}" does not exists`
+          this.pluginName,
+        )} engine on index "${index}" does not exists`,
       );
     }
 
     this.context.log.info(
-      `Update ${this.pluginName} engine on index "${index}"`
+      `Update ${this.pluginName} engine on index "${index}"`,
     );
 
     await this.engineConfigManager.createCollection(index);
@@ -131,18 +131,18 @@ export abstract class AbstractEngine<TPlugin extends Plugin> {
 
   async delete(
     index: string,
-    request?: KuzzleRequest
+    request?: KuzzleRequest,
   ): Promise<{ collections: string[] }> {
     if (!(await this.exists(index))) {
       throw new NotFoundError(
         `${Inflector.upFirst(
-          this.pluginName
-        )} engine on index "${index}" does not exists`
+          this.pluginName,
+        )} engine on index "${index}" does not exists`,
       );
     }
 
     this.context.log.info(
-      `Delete ${this.pluginName} engine on index "${index}"`
+      `Delete ${this.pluginName} engine on index "${index}"`,
     );
 
     try {
@@ -154,7 +154,7 @@ export abstract class AbstractEngine<TPlugin extends Plugin> {
         this.adminIndex,
         this.adminConfigManager.collection,
         this.engineId(index),
-        { refresh: "wait_for" }
+        { refresh: "wait_for" },
       );
     }
   }
@@ -172,7 +172,7 @@ export abstract class AbstractEngine<TPlugin extends Plugin> {
       this.adminIndex,
       this.adminConfigManager.collection,
       { query },
-      { lang: "koncorde", size: 1000 }
+      { lang: "koncorde", size: 1000 },
     );
 
     return result.hits.map((hit) => hit._source.engine);
@@ -182,7 +182,7 @@ export abstract class AbstractEngine<TPlugin extends Plugin> {
     const exists = await this.sdk.document.exists(
       this.adminIndex,
       this.adminConfigManager.collection,
-      this.engineId(index)
+      this.engineId(index),
     );
 
     return exists;

--- a/lib/engine/EngineController.ts
+++ b/lib/engine/EngineController.ts
@@ -29,7 +29,7 @@ export class EngineController<TPlugin extends Plugin> {
   constructor(
     pluginName: string,
     plugin: Plugin,
-    engine: AbstractEngine<TPlugin>
+    engine: AbstractEngine<TPlugin>,
   ) {
     this.pluginName = pluginName;
     this.config = plugin.config;

--- a/lib/synchronizer/CollectionSynchronizer.ts
+++ b/lib/synchronizer/CollectionSynchronizer.ts
@@ -9,7 +9,7 @@ import { Backend, JSONObject, KuzzleRequest } from "kuzzle";
  */
 export abstract class CollectionSynchronizer<
   SrcDoc extends { _id: string; _source: JSONObject },
-  DstDocContent
+  DstDocContent,
 > {
   protected app: Backend;
 
@@ -20,7 +20,7 @@ export abstract class CollectionSynchronizer<
   abstract convertId(srcDocument: SrcDoc, request?: KuzzleRequest): string;
   abstract convertBody(
     srcDocument: SrcDoc,
-    request?: KuzzleRequest
+    request?: KuzzleRequest,
   ): Promise<DstDocContent>;
 
   constructor(app: Backend, srcCollection: string, dstCollection: string) {
@@ -30,17 +30,17 @@ export abstract class CollectionSynchronizer<
 
     this.app.pipe.register(
       "generic:document:afterWrite",
-      (documents, request) => this.pipeAfterWrite(documents, request)
+      (documents, request) => this.pipeAfterWrite(documents, request),
     );
 
     this.app.pipe.register(
       "generic:document:afterUpdate",
-      (documents, request) => this.pipeAfterUpdate(documents, request)
+      (documents, request) => this.pipeAfterUpdate(documents, request),
     );
 
     this.app.pipe.register(
       "generic:document:beforeDelete",
-      (documents, request) => this.pipeBeforeDelete(documents, request)
+      (documents, request) => this.pipeBeforeDelete(documents, request),
     );
   }
 
@@ -58,7 +58,7 @@ export abstract class CollectionSynchronizer<
 
   async afterWriteDocuments(
     index: string,
-    documents: Array<{ _id: string; body: DstDocContent }>
+    documents: Array<{ _id: string; body: DstDocContent }>,
   ) {}
 
   async afterDeleteDocuments(index: string, ids: string[]) {}
@@ -108,7 +108,7 @@ export abstract class CollectionSynchronizer<
       await this.app.sdk.document.mDelete(
         request.getIndex(),
         this.dstCollection,
-        ids
+        ids,
       );
 
       await this.afterDeleteDocuments(request.getIndex(), ids);
@@ -119,12 +119,12 @@ export abstract class CollectionSynchronizer<
 
   private async getEntireDocuments(
     request: KuzzleRequest,
-    documents: SrcDoc[]
+    documents: SrcDoc[],
   ): Promise<SrcDoc[]> {
     const { successes } = await this.app.sdk.document.mGet(
       request.getIndex(),
       this.srcCollection,
-      documents.map(({ _id }) => _id)
+      documents.map(({ _id }) => _id),
     );
 
     return successes as SrcDoc[];
@@ -133,7 +133,7 @@ export abstract class CollectionSynchronizer<
   private async writeDocuments(
     request: KuzzleRequest,
     srcDocuments: SrcDoc[],
-    action: "create" | "update"
+    action: "create" | "update",
   ) {
     const now = Date.now();
 
@@ -160,14 +160,14 @@ export abstract class CollectionSynchronizer<
             body,
           };
         });
-      })
+      }),
     );
 
     await this.app.sdk.bulk.mWrite(
       request.getIndex(),
       this.dstCollection,
       dstDocuments,
-      { notify: true, strict: true }
+      { notify: true, strict: true },
     );
 
     await this.afterWriteDocuments(request.getIndex(), dstDocuments);

--- a/lib/utils/Ask.ts
+++ b/lib/utils/Ask.ts
@@ -5,25 +5,25 @@ export type AskEventDefinition = {
 };
 
 export type AskEventHandler<
-  TAskEventDefinition extends AskEventDefinition = AskEventDefinition
+  TAskEventDefinition extends AskEventDefinition = AskEventDefinition,
 > = (
-  payload?: TAskEventDefinition["payload"]
+  payload?: TAskEventDefinition["payload"],
 ) => Promise<TAskEventDefinition["result"]>;
 
 export function onAsk<
-  TAskEventDefinition extends AskEventDefinition = AskEventDefinition
+  TAskEventDefinition extends AskEventDefinition = AskEventDefinition,
 >(
   event: TAskEventDefinition["name"],
-  handler: AskEventHandler<TAskEventDefinition>
+  handler: AskEventHandler<TAskEventDefinition>,
 ) {
   return global.kuzzle.onAsk(event, handler);
 }
 
 export async function ask<
-  TAskEventDefinition extends AskEventDefinition = AskEventDefinition
+  TAskEventDefinition extends AskEventDefinition = AskEventDefinition,
 >(
   event: TAskEventDefinition["name"],
-  payload?: TAskEventDefinition["payload"]
+  payload?: TAskEventDefinition["payload"],
 ): Promise<TAskEventDefinition["result"]> {
   return global.kuzzle.ask(event, payload);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,13 @@
       "name": "kuzzle-plugin-commons",
       "version": "1.3.0",
       "license": "Apache 2",
+      "dependencies": {
+        "lodash": "^4.18.1"
+      },
       "devDependencies": {
         "@commitlint/cli": "19.6.1",
         "@commitlint/config-conventional": "19.6.0",
+        "@types/lodash": "^4.17.24",
         "@types/node": "22.10.7",
         "cz-conventional-changelog": "3.3.0",
         "eslint-plugin-kuzzle": "0.0.13",
@@ -2055,6 +2059,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/lodash": {
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mdast": {
       "version": "3.0.15",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.15.tgz",
@@ -3650,6 +3661,13 @@
       "engines": {
         "node": ">= 12"
       }
+    },
+    "node_modules/commitizen/node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/commitizen/node_modules/minimist": {
       "version": "1.2.7",
@@ -7645,6 +7663,13 @@
         "@types/node": ">=18"
       }
     },
+    "node_modules/kuzzle/node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/kuzzle/node_modules/mute-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
@@ -7747,9 +7772,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash-es": {

--- a/package.json
+++ b/package.json
@@ -17,9 +17,13 @@
     "test:lint:fix": "npm run test:lint -- --fix",
     "test:types": "tsc --noEmit"
   },
+  "dependencies": {
+    "lodash": "^4.18.1"
+  },
   "devDependencies": {
     "@commitlint/cli": "19.6.1",
     "@commitlint/config-conventional": "19.6.0",
+    "@types/lodash": "^4.17.24",
     "@types/node": "22.10.7",
     "cz-conventional-changelog": "3.3.0",
     "eslint-plugin-kuzzle": "0.0.13",


### PR DESCRIPTION
The PR:
- Fixes the fact that this package is using `lodash` but doesn't declare it in its `package.json` causing issues when dependencies are hoisted.
- Adds `@types/lodash` for better type checking.
- Bumps Node version to 18 in CI as GitHub dropped Node 16 support for OctoKit (GitHub SDK) causing CI failure
- Bump runner version to `ubuntu-24.04`
- Auto fix lint issues
